### PR TITLE
Add goroutine to check if Asterisk entity ID has changed.

### DIFF
--- a/proxy/types.go
+++ b/proxy/types.go
@@ -10,6 +10,7 @@ import (
 
 // AnnouncementInterval is the amount of time to wait between periodic service availability announcements
 var AnnouncementInterval = time.Minute
+var EntityCheckInterval = time.Second * 10
 
 // Announcement describes the structure of an ARI proxy's announcement of availability on the network.  These are sent periodically and upon request (by a Ping).
 type Announcement struct {

--- a/proxy/types.go
+++ b/proxy/types.go
@@ -10,6 +10,7 @@ import (
 
 // AnnouncementInterval is the amount of time to wait between periodic service availability announcements
 var AnnouncementInterval = time.Minute
+// EntityCheckInterval is the interval between checks against Asterisk entity ID
 var EntityCheckInterval = time.Second * 10
 
 // Announcement describes the structure of an ARI proxy's announcement of availability on the network.  These are sent periodically and upon request (by a Ping).


### PR DESCRIPTION
New approach for same issue, but now simple a simple os.Exit(1). Changed to goroutine since we don't need access to waitgroup in listen() function.

Now the process can run for up to 10 seconds after an Asterisk restart before a check.
One could also decode StasisStart events in eventhandler and check against node id to exit on the very first call if that's before the ticker interval, but I don't think that's worth the effort of the all the extra decoding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cycoresystems/ari-proxy/33)
<!-- Reviewable:end -->
