### PR TITLE
Add support for ARI channel redirect method

### DIFF
--- a/client/channel.go
+++ b/client/channel.go
@@ -106,6 +106,16 @@ func (c *channel) Continue(key *ari.Key, context string, extension string, prior
 	})
 }
 
+func (c *channel) Redirect(key *ari.Key, endpoint string) error {
+	return c.c.commandRequest(&proxy.Request{
+		Kind: "ChannelRedirect",
+		Key:  key,
+		ChannelRedirect: &proxy.ChannelRedirect{
+			Endpoint: endpoint,
+		},
+	})
+}
+
 func (c *channel) Busy(key *ari.Key) error {
 	return c.c.commandRequest(&proxy.Request{
 		Kind: "ChannelBusy",

--- a/internal/integration/channel.go
+++ b/internal/integration/channel.go
@@ -501,6 +501,36 @@ func TestChannelContinue(t *testing.T, s Server) {
 	})
 }
 
+func TestChannelRedirect(t *testing.T, s Server) {
+	key := ari.NewKey(ari.ChannelKey, "c1")
+
+	runTest("ok", t, s, func(t *testing.T, m *mock, cl ari.Client) {
+		m.Channel.On("Redirect", key, "edpt1").Return(nil)
+
+		err := cl.Channel().Redirect(key, "edpt1")
+		if err != nil {
+			t.Errorf("Unexpected error in remote Redirect call: %s", err)
+		}
+
+		m.Shutdown()
+
+		m.Channel.AssertCalled(t, "Redirect", key, "edpt1")
+	})
+
+	runTest("err", t, s, func(t *testing.T, m *mock, cl ari.Client) {
+		m.Channel.On("Redirect", key, "edpt1").Return(errors.New("error"))
+
+		err := cl.Channel().Redirect(key, "edpt1")
+		if err == nil {
+			t.Errorf("Expected error in remote Redirect call")
+		}
+
+		m.Shutdown()
+
+		m.Channel.AssertCalled(t, "Redirect", key, "edpt1")
+	})
+}
+
 func TestChannelDial(t *testing.T, s Server) {
 	key := ari.NewKey(ari.ChannelKey, "c1")
 

--- a/proxy/types.go
+++ b/proxy/types.go
@@ -10,6 +10,7 @@ import (
 
 // AnnouncementInterval is the amount of time to wait between periodic service availability announcements
 var AnnouncementInterval = time.Minute
+
 // EntityCheckInterval is the interval between checks against Asterisk entity ID
 var EntityCheckInterval = time.Second * 10
 
@@ -126,6 +127,7 @@ type Request struct {
 	ChannelOriginate     *ChannelOriginate     `json:"channel_originate,omitempty"`
 	ChannelPlay          *ChannelPlay          `json:"channel_play,omitempty"`
 	ChannelRecord        *ChannelRecord        `json:"channel_record,omitempty"`
+	ChannelRedirect      *ChannelRedirect      `json:"channel_redirect,omitempty"`
 	ChannelSendDTMF      *ChannelSendDTMF      `json:"channel_send_dtmf,omitempty"`
 	ChannelSnoop         *ChannelSnoop         `json:"channel_snoop,omitempty"`
 	ChannelExternalMedia *ChannelExternalMedia `json:"channel_external_media,omitempty"`
@@ -289,6 +291,12 @@ type ChannelRecord struct {
 
 	// Options is the list of recording Options
 	Options *ari.RecordingOptions `json:"options,omitempty"`
+}
+
+// ChannelRedirect describes a request to redirect a channel
+type ChannelRedirect struct {
+	// Endpoint is the endpoint to redirect the channel to
+	Endpoint string `json:"endpoint"`
 }
 
 // ChannelSendDTMF is the request for sending a DTMF event to a channel

--- a/server/channel.go
+++ b/server/channel.go
@@ -259,6 +259,10 @@ func (s *Server) channelRecord(ctx context.Context, reply string, req *proxy.Req
 	})
 }
 
+func (s *Server) channelRedirect(ctx context.Context, reply string, req *proxy.Request) {
+	s.sendError(reply, s.ari.Channel().Redirect(req.Key, req.ChannelRedirect.Endpoint))
+}
+
 func (s *Server) channelStageRecord(ctx context.Context, reply string, req *proxy.Request) {
 	data, err := s.ari.Channel().Data(req.Key)
 	if err != nil || data == nil {

--- a/server/channel_test.go
+++ b/server/channel_test.go
@@ -94,6 +94,10 @@ func TestChannelRecord(t *testing.T) {
 	integration.TestChannelRecord(t, &srv{})
 }
 
+func TestChannelRedirect(t *testing.T) {
+	integration.TestChannelRedirect(t, &srv{})
+}
+
 func TestChannelSnoop(t *testing.T) {
 	integration.TestChannelSnoop(t, &srv{})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -475,6 +475,8 @@ func (s *Server) dispatchRequest(ctx context.Context, reply string, req *proxy.R
 		f = s.channelStagePlay
 	case "ChannelRecord":
 		f = s.channelRecord
+	case "ChannelRedirect":
+		f = s.channelRedirect
 	case "ChannelStageRecord":
 		f = s.channelStageRecord
 	case "ChannelRing":


### PR DESCRIPTION
This PR adds support for ARI redirect method that tells Asterisk to redirect the channel to a different location.

https://wiki.asterisk.org/wiki/display/AST/Asterisk+13+Channels+REST+API#Asterisk13ChannelsRESTAPI-redirect

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cycoresystems/ari-proxy/39)
<!-- Reviewable:end -->
