### PR TITLE
typo in client/channel.go StageExternalMedia

### DIFF
--- a/client/channel.go
+++ b/client/channel.go
@@ -291,7 +291,7 @@ func (c *channel) StageExternalMedia(referenceKey *ari.Key, opts ari.ExternalMed
 	// Asterisk box at the time of staging even though this staging call will
 	// never actually be used.
 	k, err := c.c.createRequest(&proxy.Request{
-		Kind: "ChannelStageOriginate",
+		Kind: "ChannelStageExternalMedia",
 		Key:  referenceKey,
 		ChannelExternalMedia: &proxy.ChannelExternalMedia{
 			Options: opts,


### PR DESCRIPTION
Fixes what appears to be a copy/paste typo, resulting in Issue #48

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari-proxy/50)
<!-- Reviewable:end -->
