### PR TITLE
Add Nats connection name for management purpose

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -365,8 +365,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/rabbitmq/amqp091-go v1.4.0 h1:T2G+J9W9OY4p64Di23J6yH7tOkMocgnESvYeBjuG9cY=
-github.com/rabbitmq/amqp091-go v1.4.0/go.mod h1:JsV0ofX5f1nwOGafb8L5rBItt9GyhfQfcJj+oyz0dGg=
 github.com/rabbitmq/amqp091-go v1.5.0 h1:VouyHPBu1CrKyJVfteGknGOGCzmOz0zcv/tONLkb7rg=
 github.com/rabbitmq/amqp091-go v1.5.0/go.mod h1:JsV0ofX5f1nwOGafb8L5rBItt9GyhfQfcJj+oyz0dGg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/messagebus/messagebus.go
+++ b/messagebus/messagebus.go
@@ -72,7 +72,7 @@ type Config struct {
 	URL            string
 	TimeoutRetries int
 	RequestTimeout time.Duration
-	Application    string
+	ID             string
 }
 
 // Subscription defines subscription interface

--- a/messagebus/messagebus.go
+++ b/messagebus/messagebus.go
@@ -72,6 +72,7 @@ type Config struct {
 	URL            string
 	TimeoutRetries int
 	RequestTimeout time.Duration
+	Application    string
 }
 
 // Subscription defines subscription interface

--- a/server/server.go
+++ b/server/server.go
@@ -76,13 +76,19 @@ func (s *Server) Listen(ctx context.Context, ariOpts *native.Options, messagebus
 	switch mbtype {
 	case messagebus.TypeRabbitmq:
 		s.mbus = &messagebus.RabbitmqBus{
-			Config: messagebus.Config{URL: messagebusURL},
-			Log:    s.Log,
+			Config: messagebus.Config{
+				URL: messagebusURL,
+				ID:  "mq-" + s.Application + "-" + s.AsteriskID,
+			},
+			Log: s.Log,
 		}
 	case messagebus.TypeNats:
 		s.mbus = &messagebus.NatsBus{
-			Config: messagebus.Config{URL: messagebusURL},
-			Log:    s.Log,
+			Config: messagebus.Config{
+				URL: messagebusURL,
+				ID:  "nats-" + s.Application + "-" + s.AsteriskID,
+			},
+			Log: s.Log,
 		}
 	default:
 		return errors.New("Unkwnon url for MessageBus: " + messagebusURL)


### PR DESCRIPTION
Add Application as the name of the nats connection for management.
Should i add the asterisk.IDtoo? This will interesting as a 2nd pass
Move reconnection to the nats server instead of explicit outside

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari-proxy/52)
<!-- Reviewable:end -->
